### PR TITLE
Replace intrinsic instructions with alternative. MSVC compile fix.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.bat
 Release/*
+Debug/*
 build/*
 .lock-*
 waf*/*

--- a/src/scconsole.cpp
+++ b/src/scconsole.cpp
@@ -1,3 +1,4 @@
+#ifdef CONSOLE
 #include "scconsole.h"
 
 #include "offsets.h"
@@ -1304,3 +1305,4 @@ void PatchConsole()
     AddDrawHook(&DrawHook, 500);
     AddDrawHook(&DrawPathingInfo, 450);
 }
+#endif

--- a/src/test_game.cpp
+++ b/src/test_game.cpp
@@ -1,3 +1,4 @@
+#ifdef DEBUG
 #include "test_game.h"
 
 #include "unit.h"
@@ -1430,3 +1431,5 @@ void GameTests::NextFrame()
             INT3();
     }
 }
+
+#endif

--- a/src/unitsearch_cache.cpp
+++ b/src/unitsearch_cache.cpp
@@ -10,9 +10,6 @@
 #include "limits.h"
 
 #include <algorithm>
-#ifdef _MSC_VER
-#include <intrin.h> // For __lzcnt
-#endif
 
 #include "unitsearch_cache.hpp"
 
@@ -132,15 +129,19 @@ UnitSearchRegionCache::Entry UnitSearchRegionCache::FinishEntry(Unit **arr, uint
     return Entry(raw, Limits::Players);
 }
 
+template <typename T>
+unsigned Log2(T value)
+{
+    unsigned result = 0;
+    while (value >>= 1) ++result;
+    return result;
+}
+
 void UnitSearchAreaCache::SetSize(xuint x, yuint y)
 {
     x = (x - 1) / AreaSize + 1;
     y = (y - 1) / AreaSize + 1;
-#ifdef __GNUC__
-    width_shift = (sizeof(x) * 8) - __builtin_clz(x - 1); // Clp2
-#else
-    width_shift = (sizeof(x) * 8) - __lzcnt(x - 1); // Clp2
-#endif
+    width_shift = Log2(x - 1) + 1;
     x = 1 << width_shift;
     cache_size = x * y;
     cache.resize(cache_size);


### PR DESCRIPTION
**`src/scconsole.cpp`** - Complaint that things didn't exist.
**`src/test_game.cpp`** - Complaint that there were duplicate function bodies.
**`src/unitsearch_cache.cpp`** - Should be equivalent logic.
